### PR TITLE
zensu fails if no dependency is installed

### DIFF
--- a/zensu.sh
+++ b/zensu.sh
@@ -6,8 +6,8 @@ elif [ -e /usr/bin/kdialog ]; then
 	PASSWD=$(kdialog --title "Authentication" --password "Authentication required for $USER")
 elif [ -e /usr/bin/yad ]; then
 	PASSWD="$(yad --entry --entry-label "Password" --hide-text --image=password --window-icon=dialog-password --text="Authentication required for $USER" --title=Authentication --center)"
-elif [ -e /usr/bin/zenity ] then;
-	PASSWD="$(zenity --password --title =Authentication)"
+elif [ -e /usr/bin/zenity ]; then
+	PASSWD="$(zenity --password --title Authentication)"
 else
 	echo "Dependency not available.\n Please install at least one of: spacefm, kdialog, yad, zenity"
 fi

--- a/zensu.sh
+++ b/zensu.sh
@@ -9,7 +9,7 @@ elif [ -e /usr/bin/yad ]; then
 elif [ -e /usr/bin/zenity ] then;
 	PASSWD="$(zenity --password --title =Authentication)"
 else
-	echo "Dependincy not available.\n Please install at least one of: spacefm, kdialog, yad, zenity"
+	echo "Dependency not available.\n Please install at least one of: spacefm, kdialog, yad, zenity"
 fi
 
 if [ "$dialog_pressed_label" = 'cancel' ]; then

--- a/zensu.sh
+++ b/zensu.sh
@@ -6,8 +6,10 @@ elif [ -e /usr/bin/kdialog ]; then
 	PASSWD=$(kdialog --title "Authentication" --password "Authentication required for $USER")
 elif [ -e /usr/bin/yad ]; then
 	PASSWD="$(yad --entry --entry-label "Password" --hide-text --image=password --window-icon=dialog-password --text="Authentication required for $USER" --title=Authentication --center)"
-else
+elif [ -e /usr/bin/zenity ] then;
 	PASSWD="$(zenity --password --title =Authentication)"
+else
+	echo "Dependincy not available.\n Please install at least one of: spacefm, kdialog, yad, zenity"
 fi
 
 if [ "$dialog_pressed_label" = 'cancel' ]; then


### PR DESCRIPTION
@Chrysostomus  @yochananmarqos 
E.g. zenity is the last dependency checked but if it is not installed then the result is

```
$ zensu pcmanfm
/usr/bin/zensu: line 10: zenity: command not found
triggered empty
```