### PR TITLE
prevent unnecessary password prompt when already authenticated

### DIFF
--- a/zensu.sh
+++ b/zensu.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+if sudo -nv 2>/dev/null; then
+    sudo "$@"
+    exit $?
+fi
+
 if [ -e /usr/bin/kdialog ]; then
 	PASSWD=$(kdialog --title "Authentication" --password "Authentication required for $USER")
 elif [ -e /usr/bin/yad ]; then


### PR DESCRIPTION
This prevents asking for the password, when sudo itself wouldn't ask.